### PR TITLE
Support an interesting array of command triggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,8 @@ var bot = new Bot(bot_settings, true);
 ///////////////////////////
 // Helper methods
 function is_command(text) {
-    return text.charAt(0) == "!";
+    var valid_triggers = ["!", "⸘", "‼︎"];
+    return valid_triggers.indexOf(text.charAt(0)) > -1;
 }
 
 function parse_command(text) {


### PR DESCRIPTION
Future enhancement: actually do something different based on prefix. Suggested: `⸘` ignores the actual specified command and executes a random one, while `‼︎` is like sudo and punches through walls.